### PR TITLE
fix: Ensured correct 'secret key' value from environment variables used in POST to `/siteverify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "next-hcaptcha",
       "version": "1.4.3",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
- Fixes https://github.com/neg4n/next-hcaptcha/issues/3
- Also fixed TypeScript warnings